### PR TITLE
save/restore the contents of the screen before and after execution

### DIFF
--- a/main.c
+++ b/main.c
@@ -124,6 +124,7 @@ main(int argc, char *argv[])
 
 	set_terminal(RAW);
 
+	fputs("\033[?1049h", stderr);
 	fputs("\033[0;0H", stderr);
 	update_terminal_size();
 	draw_screen();
@@ -132,6 +133,7 @@ main(int argc, char *argv[])
 
 	/* reset the terminal */
 	update_terminal_size();
+	fputs("\033[?1049l", stderr);
 	fprintf(stderr, "\033[%d;0H\n", cols);
 	set_terminal(RESET);
 


### PR DESCRIPTION
Ideally this would be handled by a switch, but for now I think it's a sane default.