### PR TITLE
Makefile: Don't rebuild everything everytime.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,13 @@ NAME      = iode
 
 MANPREFIX = $(PREFIX)
 
-all: clean ${NAME}
+all: ${NAME}
 
 .c.o:
 	${CC} -c ${CFLAGS} $<
 
 ${NAME}: ${OBJ}
 	${CC} -o $@ ${OBJ} ${LDFLAGS}
-	rm -f *.o
 
 clean:
 	rm -f ${NAME} ${OBJ}
@@ -21,3 +20,5 @@ install: ${NAME}
 	mkdir -p  $(PREFIX)/bin $(MANPREFIX)/man/man1
 	cp *.1 $(MANPREFIX)/man/man1/
 	cp ${NAME} $(PREFIX)/bin/
+
+.PHONY clean

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ install: ${NAME}
 	cp *.1 $(MANPREFIX)/man/man1/
 	cp ${NAME} $(PREFIX)/bin/
 
-.PHONY clean
+.PHONY: clean


### PR DESCRIPTION
- remove `all`'s dependency on `clean`

- don't remove object files after linking

This allows make(1)'s built-in depency handling to only rebuild objects that have changed since `iode` was last made.

also, this makes `clean` a PHONY target -- otherwise, you'll note:

```
% touch clean
% make clean
make: 'clean' is up to date.
 ```
